### PR TITLE
Update README.md to make clear that this is a WalletConnect V1 example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# WalletConnect Example Dapp
+# WalletConnect V1 Example Dapp
+
+WalletConnect V1 is being sunset, so it is recommended to look at [WalletConnect](https://github.com/WalletConnect) V2 examples for guidance instead of this repo. 
 
 ## Develop
 


### PR DESCRIPTION
Alternatively, we could archive this repo entirely. I'm not 100% sure we don't want to update this example (or someone else could update it). 
We could also add a "[DEPRECATED]" to the title. 
